### PR TITLE
Only qbox.me support SSL.

### DIFF
--- a/lib/qiniu_direct_uploader/uploader.rb
+++ b/lib/qiniu_direct_uploader/uploader.rb
@@ -47,7 +47,7 @@ module QiniuDirectUploader
     end
 
     def action
-      @options[:action] || "http#{@options[:ssl] ? 's' : ''}://up.qiniu.com/"
+      @options[:action] || default_upload_url
     end
 
     def return_body
@@ -79,6 +79,16 @@ module QiniuDirectUploader
       put_policy.end_user = @options[:customer] if @options[:customer]
 
       Qiniu::Auth.generate_uptoken(put_policy)
+    end
+
+    private
+
+    def default_upload_url
+      if @options[:ssl]
+        "https://up.qbox.me"
+      else
+        "http://up.qiniu.com"
+      end
     end
   end
 end


### PR DESCRIPTION
`up.qiniu.com` is signed with `*.qbox.me` 's certificate, it cause browser to block uploading.

![unnamed](https://cloud.githubusercontent.com/assets/214616/10012467/ddb9e2a8-613a-11e5-87d0-a4a95a8d3884.png)

Qiniu provide another interface for ssl uploading: `up.qbox.me`